### PR TITLE
WIP: Queries on NDSparse

### DIFF
--- a/src/NDSparseData.jl
+++ b/src/NDSparseData.jl
@@ -528,4 +528,6 @@ end
 
 sum(x::NDSparse) = sum(x.data)
 
+include("query.jl")
+
 end # module

--- a/src/query.jl
+++ b/src/query.jl
@@ -1,0 +1,64 @@
+export naturaljoin
+
+## Joins
+
+# Natural Join (Both NDSParse arrays must have the same number of columns, in the same order)
+
+function naturaljoin(left::NDSparse, right::NDSparse, op::Function)
+   lI = left.indexes
+   rI = right.indexes
+   lD = left.data
+   rD = right.data
+
+   ll, rr = length(lI), length(rI)
+
+   # Guess the length of the result
+   guess = min(ll, rr)
+
+   # Initialize output array components
+   I = Indexes(map(c->sizehint!(similar(c,0) ,guess), lI.columns)...)
+   data = sizehint!(similar(lD, 0), guess)
+   default = left.default
+
+   # Match and insert rows
+   i = j = 1
+
+   while i <= ll && j <= rr
+      lt, rt = lI[i], rI[j]
+      c = cmp(lt, rt)
+      if c == 0
+         pushrow!(I, lt)
+         push!(data, op(lD[i], rD[j]))
+         i += 1
+         j += 1
+      elseif c < 0
+         i += 1
+      else
+         j += 1
+      end
+   end
+
+   # Generate final datastructure
+   NDSparse(I, data, default)
+end
+
+
+# Column-wise filtering (Accepts conditions as column-function pairs)
+# Example: select(arr, 1 => x->x>10, 3 => x->x!=10 ...)
+
+function Base.select(arr::NDSparse, conditions::Pair...)
+   indxs = 1:length(arr)
+   cols = arr.indexes.columns
+   for (c,f) in conditions
+      indxs = intersect(indxs, filter(i->f(cols[c][i]), indxs))
+   end
+   NDSparse(Indexes(map(x->x[indxs], cols)...), arr.data[indxs], arr.default)
+end
+
+# Filter on data field
+function Base.filter(fn::Function, arr::NDSparse)
+   cols = arr.indexes.columns
+   data = arr.data
+   indxs = filter(i->fn(data[i]), eachindex(data))
+   NDSparse(Indexes(map(x->x[indxs], cols)...), data[indxs], arr.default)
+end


### PR DESCRIPTION
SQL like queries on NDSparse arrays. I think a generalized (outer, inner, theta etc.) join can also be done, but it feels awkward using column indices instead of column names. 

Here's a demo:
```julia
 a = NDSparse([12,21,32], [52,41,34], [11,53,150])
# NDSparse{Int64,Tuple{Int64,Int64}}:
# (12,52) => 11
# (21,41) => 53
# (32,34) => 150

b = NDSparse([12,23,32], [52,43,34], [56,13,10])
# NDSparse{Int64,Tuple{Int64,Int64}}:
# (12,52) => 56
# (23,43) => 13
# (32,34) => 10

naturaljoin(a, b, +)
# NDSparse{Int64,Tuple{Int64,Int64}}:
# (12,52) => 67
# (32,34) => 160

select(a, 1=>x->x<30, 2=>x->x>40)
# NDSparse{Int64,Tuple{Int64,Int64}}:
# (12,52) => 11
# (21,41) => 53

filter(x->x>100, a)
# NDSparse{Int64,Tuple{Int64,Int64}}:
# (32,34) => 150
```

cc @shashi 