### PR TITLE
RFC: remove stored default value

### DIFF
--- a/benchmarks/run.jl
+++ b/benchmarks/run.jl
@@ -8,7 +8,7 @@ suite = BenchmarkGroup()
 ###
 
 function copy_unflushed(cols, data)
-   NDSparse(Indexes(map(c->similar(c, 0), cols)...), similar(data, 0), false, Indexes(deepcopy(cols)...), copy(data))
+   NDSparse(Indexes(map(c->similar(c, 0), cols)...), similar(data, 0), Indexes(deepcopy(cols)...), copy(data))
 end
 
 function copy_flushed(cols, data)
@@ -35,7 +35,7 @@ function construction_suite(N::Int, D::Int, cols)
 
    suite = BenchmarkGroup(["Construction"])
    suite["numeric"] = @benchmarkable NDSparse(c..., d) setup=(c = deepcopy($cols); d = copy($numeric_data))
-   suite["mixed"] = @benchmarkable NDSparse(Indexes(c...), d, nothing) setup=(c = deepcopy($cols); d = $mixed_data)
+   suite["mixed"] = @benchmarkable NDSparse(c..., d) setup=(c = deepcopy($cols); d = $mixed_data)
    return suite
 end
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -18,7 +18,6 @@ function naturaljoin(left::NDSparse, right::NDSparse, op::Function)
    # Initialize output array components
    I = Indexes(map(c->_sizehint!(similar(c,0), guess), lI.columns)...)
    data = _sizehint!(similar(lD, 0), guess)
-   default = left.default
 
    # Match and insert rows
    i = j = 1
@@ -39,7 +38,7 @@ function naturaljoin(left::NDSparse, right::NDSparse, op::Function)
    end
 
    # Generate final datastructure
-   NDSparse(I, data, default)
+   NDSparse(I, data)
 end
 
 
@@ -52,7 +51,7 @@ function Base.select(arr::NDSparse, conditions::Pair...)
     for (c,f) in conditions
         filter!(i->f(cols[c][i]), indxs)
     end
-    NDSparse(Indexes(map(x->x[indxs], cols)...), arr.data[indxs], arr.default)
+    NDSparse(Indexes(map(x->x[indxs], cols)...), arr.data[indxs])
 end
 
 # select a subset of columns
@@ -65,5 +64,5 @@ function Base.filter(fn::Function, arr::NDSparse)
    cols = arr.indexes.columns
    data = arr.data
    indxs = filter(i->fn(data[i]), eachindex(data))
-   NDSparse(Indexes(map(x->x[indxs], cols)...), data[indxs], arr.default)
+   NDSparse(Indexes(map(x->x[indxs], cols)...), data[indxs])
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,8 +27,6 @@ isless(a::Dimension, b::Dimension) = isless(a.value, b.value)
 convert{T<:Real}(::Type{T}, d::Dimension{T}) = d.value
 convert{T<:Dimension}(::Type{T}, x::Real) = T(x)
 
-default{T}(D::Type{Dimension{T}}) = D(default(T))
-
 function show(io::IO, d::Dimension)
     print(io, typeof(d).name, "(")
     show(io, d.value)

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -50,7 +50,7 @@ let a = NDSparse([12,21,32], [52,41,34], [11,53,150]), b = NDSparse([12,23,32], 
     @test c[20,20] == 97
 
     c = map(+, a, b)
-    @test length(c.indexes) == 4
+    @test length(c.indexes) == 2
     @test sum(map(-, c, c)) == 0
 end
 


### PR DESCRIPTION
I think we will be better off without storing a default value for each array. It wasn't clear what the default value means in full generality, and only `map` was actually using it. Instead, we can use standard joins, and with this change `map` and `naturaljoin` do the same thing so we don't need both. Also, some data types do not have obvious default values.