### PR TITLE
add NamedTuple support for named columns and struct-of-arrays data

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.4
+julia 0.5-
+NamedTuples

--- a/src/NDSparseData.jl
+++ b/src/NDSparseData.jl
@@ -1,5 +1,7 @@
 module NDSparseData
 
+using NamedTuples
+
 import Base:
     show, eltype, length, getindex, setindex!, ndims, map, convert,
     ==, broadcast, broadcast!, empty!, copy, similar, sum, merge,
@@ -10,7 +12,7 @@ export NDSparse, flush!, aggregate!, where, pairs, convertdim
 include("utils.jl")
 include("columns.jl")
 
-immutable NDSparse{T, D<:Tuple, C<:Tuple, V<:AbstractVector}
+immutable NDSparse{T, D<:Union{Tuple,NamedTuple}, C<:Tuple, V<:AbstractVector}
     index::Columns{D,C}
     data::V
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -6,16 +6,26 @@ import Base:
 
 export Columns
 
-immutable Columns{D<:Union{Tuple,NamedTuple}, C<:Tuple} <: AbstractVector{D}
+immutable Columns{D<:Tup, C<:Tup} <: AbstractVector{D}
     columns::C
+
+    function Columns(c)
+        length(c) > 0 || error("must have at least one column")
+        n = length(c[1])
+        for i = 2:length(c)
+            length(c[i]) == n || error("all columns must have same length")
+        end
+        new(c)
+    end
 end
 
 function Columns(cols::AbstractVector...; names::Union{Vector{Symbol},Tuple{Vararg{Symbol}},Void}=nothing)
     if isa(names, Void)
         Columns{eltypes(typeof(cols)),typeof(cols)}(cols)
     else
-        et = eval(:(@NT($(names...)))){map(eltype, cols)...}
-        Columns{et,typeof(cols)}(cols)
+        dt = eval(:(@NT($(names...)))){map(eltype, cols)...}
+        ct = eval(:(@NT($(names...)))){map(typeof, cols)...}
+        Columns{dt,ct}(ct(cols...))
     end
 end
 
@@ -23,9 +33,8 @@ Columns(; pairs...) = Columns(map(x->x[2],pairs)..., names=Symbol[x[1] for x in 
 
 (::Type{Columns{D}}){D}(columns::AbstractVector...) = Columns{D,typeof(columns)}(columns)
 
-@generated function astuple(n::NamedTuple)
-    Expr(:tuple, [ Expr(:., :n, Expr(:quote, fieldname(n,i))) for i = 1:nfields(n) ]...)
-end
+Columns(c::Tuple) = Columns{eltypes(typeof(c)),typeof(c)}(c)
+Columns(c::NamedTuple) = Columns{Tuple{typeof(c).types...},typeof(c)}(c)
 
 eltype{D,C}(::Type{Columns{D,C}}) = D
 length(c::Columns) = length(c.columns[1])
@@ -35,25 +44,18 @@ linearindexing{T<:Columns}(::Type{T}) = Base.LinearFast()
 summary{D<:Tuple}(c::Columns{D}) = "Columns{$D}"
 
 empty!(c::Columns) = (map(empty!, c.columns); c)
-similar{D}(c::Columns{D}) = empty!(Columns{D}(map(similar, c.columns)...))
-similar{D}(c::Columns{D}, n::Integer) = Columns{D}(map(a->similar(a,n), c.columns)...)
-copy{D}(c::Columns{D}) = Columns{D}(map(copy, c.columns)...)
-
-@inline ith_all(i, ::Tuple{}) = ()
-@inline ith_all(i, as) = (as[1][i], ith_all(i, tail(as))...)
+similar{D,C}(c::Columns{D,C}) = empty!(Columns{D,C}(map(similar, c.columns)))
+similar{D,C}(c::Columns{D,C}, n::Integer) = Columns{D,C}(map(a->similar(a,n), c.columns))
+copy{D,C}(c::Columns{D,C}) = Columns{D,C}(map(copy, c.columns))
 
 getindex{D<:Tuple}(c::Columns{D}, i::Integer) = ith_all(i, c.columns)
 getindex{D<:NamedTuple}(c::Columns{D}, i::Integer) = D(ith_all(i, c.columns)...)
 
-getindex{D}(c::Columns{D}, p::AbstractVector) = Columns{D}(map(c->c[p], c.columns)...)
+getindex{D,C}(c::Columns{D,C}, p::AbstractVector) = Columns{D,C}(map(c->c[p], c.columns))
 
-setindex!(I::Columns, r::Tuple, i) = (_setindex!(I.columns[1], r[1], i, tail(I.columns), tail(r)); I)
-@inline _setindex!(c1, r1, i, cr, rr) = (c1[i]=r1; _setindex!(cr[1], rr[1], i, tail(cr), tail(rr)))
-@inline _setindex!(c1, r1, i, cr::Tuple{}, rr) = (c1[i] = r1)
+setindex!(I::Columns, r::Tup, i::Integer) = (foreach((c,v)->(c[i]=v), I.columns, r); I)
 
-push!(I::Columns, r::Tuple) = _pushrow!(I.columns[1], r[1], tail(I.columns), tail(r))
-@inline _pushrow!(c1, r1, cr, rr) = (push!(c1, r1); _pushrow!(cr[1], rr[1], tail(cr), tail(rr)))
-@inline _pushrow!(c1, r1, cr::Tuple{}, rr) = push!(c1, r1)
+push!(I::Columns, r::Tup) = (foreach(push!, I.columns, r); I)
 
 function ==(x::Columns, y::Columns)
     length(x.columns) == length(y.columns) || return false
@@ -82,16 +84,23 @@ end
 sort!(c::Columns) = permute!(c, sortperm(c))
 sort(c::Columns) = c[sortperm(c)]
 
-# row operations
+# fused indexing operations
+# these can be implemented for custom vector types like PooledVector where
+# you can get big speedups by doing indexing and an operation in one step.
 
 @inline cmpelts(a, i, j) = (@inbounds x=cmp(a[i], a[j]); x)
+@inline copyelt!(a, i, j) = (@inbounds a[i] = a[j])
+
+# row operations
+
+copyrow!(I::Columns, i, src) = foreach(c->copyelt!(c, i, src), I.columns)
 
 @generated function rowless{D,C}(c::Columns{D,C}, i, j)
     N = length(C.parameters)
-    ex = :(cmpelts(c.columns[$N], i, j) < 0)
+    ex = :(cmpelts(getfield(c.columns,$N), i, j) < 0)
     for n in N-1:-1:1
         ex = quote
-            let d = cmpelts(c.columns[$n], i, j)
+            let d = cmpelts(getfield(c.columns,$n), i, j)
                 (d == 0) ? ($ex) : (d < 0)
             end
         end
@@ -101,10 +110,10 @@ end
 
 @generated function rowcmp{D}(c::Columns{D}, i, d::Columns{D}, j)
     N = length(D.parameters)
-    ex = :(cmp(c.columns[$N][i], d.columns[$N][j]))
+    ex = :(cmp(getfield(c.columns,$N)[i], getfield(d.columns,$N)[j]))
     for n in N-1:-1:1
         ex = quote
-            let k = cmp(c.columns[$n][i], d.columns[$n][j])
+            let k = cmp(getfield(c.columns,$n)[i], getfield(d.columns,$n)[j])
                 (k == 0) ? ($ex) : k
             end
         end
@@ -114,17 +123,11 @@ end
 
 @generated function roweq{D,C}(c::Columns{D,C}, i, j)
     N = length(C.parameters)
-    ex = :(cmpelts(c.columns[1], i, j) == 0)
+    ex = :(cmpelts(getfield(c.columns,1), i, j) == 0)
     for n in 2:N
         ex = quote
-            ($ex) && (cmpelts(c.columns[$n], i, j)==0)
+            ($ex) && (cmpelts(getfield(c.columns,$n), i, j)==0)
         end
     end
     ex
 end
-
-@inline copyelt!(a, i, j) = (@inbounds a[i] = a[j])
-
-copyrow!(I::Columns, i, src) = _copyrow!(I.columns[1], tail(I.columns), i, src)
-@inline _copyrow!(c1, cr, i, src) = (copyelt!(c1, i, src); _copyrow!(cr[1], tail(cr), i, src))
-@inline _copyrow!(c1, cr::Tuple{}, i, src) = copyelt!(c1, i, src)


### PR DESCRIPTION
The approach is (1) use `Columns` for both indexes and data, (2) bring in NamedTuples. Example:

```
julia> NDSparse(rand(3), Columns(open = rand(3), close = rand(3)))
NDSparse{NDSparseData._NT_openclose{Float64,Float64},Tuple{Float64}}:
 (0.07459099981805961,) => (open => 0.39695970629326216, close => 0.8768181865079363)
 (0.23068405270544878,) => (open => 0.21901570490914923, close => 0.9516909318576521)
 (0.8329699883751216,) => (open => 0.23058501858024938, close => 0.8031837612378654)
```
